### PR TITLE
Version of keycloak changed to 10.0.2.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -36,6 +36,14 @@ Security is both role based (RBAC) and attribute based (ABAC).
 Build Process
 =============
 
+## Build keycloak so that jar files are present in local maven repository
+
+1. Clone https://github.com/atlanhq/keycloak/
+2. Checkout `keycloak-atlas` branch
+3. Run `mvn install -Dmaven.test.skip -DskipTestsuite=true`
+
+
+## Build Atlas
 1. Get Atlas sources to your local directory, for example with following commands
    $ cd <your-local-directory>
    $ git clone https://github.com/apache/atlas.git

--- a/pom.xml
+++ b/pom.xml
@@ -730,7 +730,7 @@
         <!-- Storm dependencies -->
 
         <!-- keycloak dependencies -->
-        <keycloak.version>6.0.1</keycloak.version>
+        <keycloak.version>10.0.2.1</keycloak.version>
         <!-- keycloak dependencies -->
 
         <PermGen>64m</PermGen>


### PR DESCRIPTION
The Keycloak dependency that Atlas use has an `issuer` check which checks the `issuer` in the JWT. So in version 10.0.2.1 we have removed the `issuer` check for the JWT.